### PR TITLE
Fixed library requiring importation of std/atomics by user

### DIFF
--- a/loony.nimble
+++ b/loony.nimble
@@ -1,4 +1,4 @@
-version = "0.1.1"
+version = "0.1.2"
 author = "cabboose"
 description = "fast mpmc queue with sympathetic memory behavior"
 license = "MIT"


### PR DESCRIPTION
The example provided would not work without the user importing std/atomics. The templates fetchAddHead and fetchAddTail were changed to procedures to amend this without polluting the users name space.