### PR TITLE
simplify and revert optional memory ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,9 @@ jobs:
           balls --path="." --cc:clang --gc:arc --backend:c --define:danger --define:release
 
       - name: Build docs
-        if: ${{ matrix.docs }} == 'true'
+        if: >
+          github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+          matrix.os == 'ubuntu-latest' && matrix.compiler.version == 'version-2-0'
         run: |
           branch=${{ github.ref }}
           branch=${branch##*/}
@@ -141,7 +143,7 @@ jobs:
       - name: Publish docs
         if: >
           github.event_name == 'push' && github.ref == 'refs/heads/main' &&
-          matrix.os == 'ubuntu-latest' && matrix.nim == 'version-2-0'
+          matrix.os == 'ubuntu-latest' && matrix.compiler.version == 'version-2-0'
         uses: crazy-max/ghaction-github-pages@v3.1.0
         with:
           build_dir: project/docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,14 @@ on:
 
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - '*'
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   changes:
@@ -23,10 +26,10 @@ jobs:
       # For PRs the path filter check with Github API, so no need to checkout
       # for them.
       - if: github.event_name != 'pull_request'
-        name: Checkout (if not PR)
-        uses: actions/checkout@v2
+        name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -51,41 +54,76 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['macos-latest', 'ubuntu-latest']
-        nim: ['devel']
-    name: '${{ matrix.os }} (${{ matrix.nim }})'
+        os: [ubuntu-latest]
+        compiler:
+          - name: nim
+            version: version-2-0
+          - name: nimskull
+            version: "*"
+
+    name: '${{ matrix.os }} (${{ matrix.compiler.name }} ${{ matrix.compiler.version }})'
     runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: project
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          path: ci
+          path: project
 
-      - name: Setup Nim
+      - name: Nim
+        if: matrix.compiler.name == 'nim'
         uses: alaviss/setup-nim@0.1.1
         with:
           path: nim
-          version: ${{ matrix.nim }}
+          version: ${{ matrix.compiler.version }}
+
+      - name: Nimskull
+        id: nimskull
+        if: matrix.compiler.name == 'nimskull'
+        uses: nim-works/setup-nimskull@0.1.2
+        with:
+          nimskull-version: ${{ matrix.compiler.version }}
+
+      - name: Fetch Nimble
+        if: matrix.compiler.name == 'nimskull'
+        uses: actions/checkout@v4.1.1
+        with:
+          path: nimble
+          repository: alaviss/nimble
+          ref: nimskull
+
+      - name: Build Nimble
+        if: matrix.compiler.name == 'nimskull'
+        run: |
+          nim c -d:release -o:"$NIMSKULL_BIN/nimble" src/nimble.nim
+          # Add nimble binary folder to PATH
+          echo "$HOME/.nimble/bin" >> "$GITHUB_PATH"
+        working-directory: nimble
+        env:
+          NIMSKULL_BIN: ${{ steps.nimskull.outputs.bin-path }}
 
       - name: Dependencies
-        shell: bash
         run: |
-          cd ci
           nimble --accept install "https://github.com/nim-works/cps"
           nimble --accept install "https://github.com/disruptek/balls"
           nimble --accept develop
 
-      - name: Tests
-        shell: bash
+      - name: Tests (gcc)
         run: |
-          cd ci
-          balls --path="." --gc:arc --backend:c --define:danger --define:release
+          balls --path="." --cc:gcc --gc:arc --backend:c --define:danger --define:release
+
+      - name: Tests (clang)
+        run: |
+          balls --path="." --cc:clang --gc:arc --backend:c --define:danger --define:release
 
       - name: Build docs
         if: ${{ matrix.docs }} == 'true'
-        shell: bash
         run: |
-          cd ci
           branch=${{ github.ref }}
           branch=${branch##*/}
           nimble doc --project --outdir:docs --path="." \
@@ -102,19 +140,23 @@ jobs:
           cp docs/{the,}index.html || true
       - name: Publish docs
         if: >
-          github.event_name == 'push' && github.ref == 'refs/heads/master' &&
-          matrix.os == 'ubuntu-latest' && matrix.nim == 'devel'
-        uses: crazy-max/ghaction-github-pages@v2.5.0
+          github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+          matrix.os == 'ubuntu-latest' && matrix.nim == 'version-2-0'
+        uses: crazy-max/ghaction-github-pages@v3.1.0
         with:
-          build_dir: ci/docs
+          build_dir: project/docs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Set check-required on this
   success:
     needs: build
+    if: always()
     runs-on: ubuntu-latest
     name: 'All check passes'
     steps:
-      - run: |
-          echo "This is a workaround for Github's broken software"
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        name: 'Fail when previous jobs fails'
+        run: |
+          echo "::error::One of the previous jobs failed"
+          exit 1

--- a/loony/spec.nim
+++ b/loony/spec.nim
@@ -62,14 +62,14 @@ proc getHigh*(mask: ControlMask): uint16 =
 proc getLow*(mask: ControlMask): uint16 =
   mask.uint16
 
-proc fetchAddTail*(ctrl: var ControlBlock, v: uint32 = 1, moorder: MemoryOrder = moRelease): ControlMask =
-  ctrl.tailMask.fetchAdd(v, order = moorder)
+proc fetchAddTail*(ctrl: var ControlBlock, v: uint32 = 1): ControlMask =
+  ctrl.tailMask.fetchAdd(v, order = moRelaxed)
 
-proc fetchAddHead*(ctrl: var ControlBlock, v: uint32 = 1, moorder: MemoryOrder = moRelease): ControlMask =
-  ctrl.headMask.fetchAdd(v, order = moorder)
+proc fetchAddHead*(ctrl: var ControlBlock, v: uint32 = 1): ControlMask =
+  ctrl.headMask.fetchAdd(v, order = moRelaxed)
 
-proc fetchAddReclaim*(ctrl: var ControlBlock, v: uint8 = 1, moorder: MemoryOrder = moAcquireRelease): uint8 =
-  ctrl.reclaim.fetchAdd(v, order = moorder)
+proc fetchAddReclaim*(ctrl: var ControlBlock, v: uint8 = 1): uint8 =
+  ctrl.reclaim.fetchAdd(v, order = moAcquireRelease)
 
 when defined(loonyDebug):
   import std/logging

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -30,13 +30,14 @@ setLogFilter:
 var q: LoonyQueue[Continuation]
 
 proc runThings() {.thread.} =
-  while true:
-    var job = pop q
-    if job.dismissed:
-      break
-    else:
-      while job.running:
-        job = trampoline job
+  {.gcsafe.}:
+    while true:
+      var job = pop q
+      if job.dismissed:
+        break
+      else:
+        while job.running:
+          job = trampoline job
 
 proc enqueue(c: C): C {.cpsMagic.} =
   check not q.isNil
@@ -61,7 +62,7 @@ else:
     var x = Timespec(tv_sec: 0.Time, tv_nsec: ns)
     var y: Timespec
     if 0 != nanosleep(x, y):
-      raise
+      fail "nanosleep fail"
     c
 
 proc doContinualThings() {.cps: C.} =


### PR DESCRIPTION
This undoes some misguided shenanigans added to green up sanitizer tests.