### PR TITLE
Implement optional flag for rotating index

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ tests and further documentation are to follow when time allows.
 
 [The full API documentation is kept up-to-date on GitHub.](https://nim-works.github.io/loony/loony.html)
 
-[The API documentation for the Ward submodule is found here.](https://nim-works.github.io/loony/loony/ward.html)
+[~~The API documentation for the Ward submodule is found here.~~](https://nim-works.github.io/loony/loony/ward.html) ~~*Wards are untested and are unlikely to remain in the library*~~
 
 #### Memory Safety & Cache Coherence
 
@@ -113,6 +113,19 @@ primitives such as `atomic_thread_fence` to ensure a CPU's store buffer is
 committed on the push operation and read on the pop operation; this is a
 higher-cost primitive. You can use `unsafePush` and `unsafePop` to manipulate
 a `LoonyQueue` without regard to cache coherency for ultimate performance.
+
+The LoonyQueue itself is padded across cachelines, and by default, the slots
+are read and written to in a cyclic fashion over cachelines to reduce false
+sharing.
+
+```
+Visual representation of rotating index
+
+| 64 bytes | 64 bytes | 64 bytes |...
+| 0------- | 1------- | 2------- |...
+| -63------| -64------| -65------|...
+|--127-----|--128-----|--129-----|...
+```
 
 ### Debugging
 
@@ -140,7 +153,19 @@ debugNodeCounter:
 We recommend against changing these values unless you know what you are doing. The suggested max alignment is 16 to achieve drastically higher contention capacities. Compilation will fail if your alignment does not fit the slot count index.
 
 `-d:loonyNodeAlignment=11` - Adjust node alignment to increase/decrease contention capacity
+
 `-d:loonySlotCount=1024` - Adjust the number of slots in each node
+
+`-d:loonyDebug=false` - Toggle debug counters and templates, see
+[debugging](#debugging). False by default.
+
+`-d:loonyRotate=true` - Toggle the index for the slots of
+loony queue to be read over cacheline bounds in a cyclic
+manner. True by default.
+
+> While loonyRotate is enabled, the slot count must be a
+> power of 2. Error messages will indicate whether this
+> is a cause of compilation failure.
 
 ## What are Continuations?
 

--- a/loony.nim
+++ b/loony.nim
@@ -28,6 +28,13 @@ type
     head     {.align: 128.}: Atomic[TagPtr]     ## Whereby node contains the slots and idx
     tail     {.align: 128.}: Atomic[TagPtr]     ## is the uint16 index of the slot array
     currTail {.align: 128.}: Atomic[NodePtr]    ## 8 bytes Current NodePtr
+  # Align to 128 bytes to avoid false sharing, see:
+  # https://stackoverflow.com/questions/72126606/should-the-cache-padding-size-of-x86-64-be-128-bytes
+  # Plenty of architectural differences can impact whether
+  # or not 128 bytes is superior alignment to 64 bytes, but
+  # considering the cost that this change introduces to the
+  # memory consumption of the loony queue object, it is
+  # recommended.
 
   ## Result types for the private
   ## advHead and advTail functions

--- a/loony.nim
+++ b/loony.nim
@@ -25,9 +25,9 @@ type
 
   LoonyQueue*[T] = ref LoonyQueueImpl[T]
   LoonyQueueImpl*[T] = object
-    head     : Atomic[TagPtr]     ## Whereby node contains the slots and idx
-    tail     : Atomic[TagPtr]     ## is the uint16 index of the slot array
-    currTail : Atomic[NodePtr]    ## 8 bytes Current NodePtr
+    head     {.align: 128.}: Atomic[TagPtr]     ## Whereby node contains the slots and idx
+    tail     {.align: 128.}: Atomic[TagPtr]     ## is the uint16 index of the slot array
+    currTail {.align: 128.}: Atomic[NodePtr]    ## 8 bytes Current NodePtr
 
   ## Result types for the private
   ## advHead and advTail functions

--- a/loony.nimble
+++ b/loony.nimble
@@ -1,4 +1,4 @@
-version = "0.3.0"
+version = "0.3.1"
 author = "cabboose"
 description = "Fast mpmc queue with sympathetic memory behavior"
 license = "MIT"

--- a/loony/spec.nim
+++ b/loony/spec.nim
@@ -9,7 +9,7 @@ const
   ## owner.  Note that in particular, child Continuations have cycles,
   ## which will trigger a failure of this assertion.
 
-  loonyRotate* {.booldefine.} = false ## Indicate that loony should rotate
+  loonyRotate* {.booldefine.} = true ## Indicate that loony should rotate
   ## the slots in the queue to avoid contention on the same cache line.
   ## This is useful when the queue is shared between multiple threads.
   ## Note that this will only work if the number of slots is a power of 2.

--- a/loony/spec.nim
+++ b/loony/spec.nim
@@ -1,7 +1,7 @@
-import std/[atomics, math]
+import std/[atomics, math, strformat]
 
 const
-  loonyNodeAlignment {.intdefine.} = 11
+  loonyNodeAlignment* {.intdefine.} = 11
   loonySlotCount* {.intdefine.} = 1024
 
   loonyIsolated* {.booldefine.} = false  ## Indicate that loony should
@@ -15,7 +15,7 @@ const
   ## Note that this will only work if the number of slots is a power of 2.
 
 when loonyRotate:
-  # Impl dynamic cache line size detection
+  # TODO Impl dynamic cache line size detection
   const
     cacheLineSize = 64
     lShiftBits* = int log2(float cacheLineSize)
@@ -26,7 +26,9 @@ static:
     "Your LoonySlot count exceeds your alignment!"
   when loonyRotate:
     doAssert (loonySlotCount and (loonySlotCount - 1)) == 0,
-      "LoonySlot count must be a power of 2!"
+      fmt"Your LoonySlot count of {loonySlotCount} is not a power of 2!" &
+      " Either disable loonyRotate (-d:loonyRotate=false) or" &
+      " change the slot count."
 
 const
   ## Slot flag constants

--- a/loony/spec.nim
+++ b/loony/spec.nim
@@ -24,6 +24,8 @@ when loonyRotate:
 static:
   doAssert (1 shl loonyNodeAlignment) > loonySlotCount,
     "Your LoonySlot count exceeds your alignment!"
+  doAssert loonySlotCount > 1,
+    "Your LoonySlot count must be greater than 1!"
   when loonyRotate:
     doAssert (loonySlotCount and (loonySlotCount - 1)) == 0,
       fmt"Your LoonySlot count of {loonySlotCount} is not a power of 2!" &


### PR DESCRIPTION
## -d:loonyRotate

This flag indicates that slots are not to be read in sequential order, but rather in a incremental cyclic pattern, stepping over cache lines.

### Motivation

Potential reduction in cache coherency overhead from MESI protocol invalidations, false sharing etc